### PR TITLE
Update a Dart Sass Host to version 2.0.5

### DIFF
--- a/src/DartSassBuildWatcherTool/DartSassBuildWatcherTool.csproj
+++ b/src/DartSassBuildWatcherTool/DartSassBuildWatcherTool.csproj
@@ -24,13 +24,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="DartSassHost" Version="1.0.12" />
-    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.24.1" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.4.4" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.4.4" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.4.4" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.4.4" />
-    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.4.4" />
+    <PackageReference Include="DartSassHost" Version="2.0.5" />
+    <PackageReference Include="JavaScriptEngineSwitcher.V8" Version="3.31.0" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.linux-x64" Version="7.5.0" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-x64" Version="7.5.0" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.osx-arm64" Version="7.5.0" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x64" Version="7.5.0" />
+    <PackageReference Include="Microsoft.ClearScript.V8.Native.win-x86" Version="7.5.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
   </ItemGroup>
   


### PR DESCRIPTION
Hello, Sergey!

Performance has been significantly increased in version 2.X, so I recommend that you update it, as well as its dependencies, to the latest versions.